### PR TITLE
Fix WebSocket connect requests

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -10,6 +10,10 @@ import (
 // serveConnect handles a CONNECT call on a.config.Addr and connects it to the
 // tlsProxy on a.config.TLSAddr
 func (a *App) serveConnect(rw http.ResponseWriter, req *http.Request) {
+	if req.URL.Port() != "443" {
+		return
+	}
+
 	destConn, err := net.DialTimeout("tcp", a.config.TLSAddr, 10*time.Second)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusServiceUnavailable)

--- a/connect.go
+++ b/connect.go
@@ -5,16 +5,18 @@ import (
 	"net"
 	"net/http"
 	"time"
+	"strings"
 )
 
 // serveConnect handles a CONNECT call on a.config.Addr and connects it to the
 // tlsProxy on a.config.TLSAddr
-func (a *App) serveConnect(rw http.ResponseWriter, req *http.Request) {
-	if req.URL.Port() != "443" {
-		return
+func (a *App) serveConnect(rw http.ResponseWriter, req *http.Request, entry *Entry) {
+	destHost := strings.TrimPrefix(entry.DestHost, "http://")
+	if req.URL.Port() == "443" {
+		destHost = a.config.TLSAddr
 	}
 
-	destConn, err := net.DialTimeout("tcp", a.config.TLSAddr, 10*time.Second)
+	destConn, err := net.DialTimeout("tcp", destHost, 10*time.Second)
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusServiceUnavailable)
 		return

--- a/http.go
+++ b/http.go
@@ -42,7 +42,7 @@ func (a *App) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 			if req.Method == "CONNECT" {
 				log.Printf("%s (received CONNECT)", colors[c](host))
-				a.serveConnect(rw, req)
+				a.serveConnect(rw, req, h.e)
 			} else {
 				log.Println(colors[c](host), pth)
 				h.ServeHTTP(rw, req)


### PR DESCRIPTION
Hi @octavore, this fixes errors on WebSocket connect requests by checking if port is 443 in serveConnect. If there is a better way to check if the connect request is related to TLS, please let me know and I will update my PR. Thanks!